### PR TITLE
chore/add-provider

### DIFF
--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,5 @@
+provider "aws" {
+  access_key = var.aws_access_key
+  secret_key = var.aws_secret_key
+  region     = var.aws_region
+}


### PR DESCRIPTION
## Terraform AWS Provider Configuration

This pull request introduces the AWS provider configuration for managing ECS infrastructure. The `provider.tf` file is added to set up the AWS provider with the necessary credentials and region.

### Changes Made
- Added `provider.tf` file with AWS provider configuration.
  - Access Key
  - Secret Key
  - Region

### Context
The AWS provider configuration is a crucial component for Terraform to interact with AWS services. It includes the access key, secret key, and region required for managing resources on the AWS platform. Ensure that sensitive information, such as access and secret keys, is handled securely, and consider using AWS IAM roles with the least privilege principle for enhanced security.

### Testing
Verify that the AWS provider configuration allows Terraform to authenticate and communicate with AWS services successfully. Run appropriate Terraform commands to plan and apply changes, ensuring that the AWS provider is initialized correctly.

### Checklist
- [x] AWS provider configuration does not contain hard-coded sensitive information.
- [x] AWS provider configuration uses variables for access key, secret key, and region.
- [x] Tested the AWS provider configuration with Terraform commands.
- [x] No unnecessary changes in other files.

Please review and merge this PR to proceed with setting up the AWS provider for ECS infrastructure.
