### PR TITLE
chore/add-variables

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,51 @@
+variable "aws_access_key" {
+  description = "The IAM public access key"
+}
+
+variable "aws_secret_key" {
+  description = "The IAM secret access key"
+}
+
+variable "aws_region" {
+  description = "The AWS region to use"
+}
+
+variable "ec2_task_execution_role_name" {
+  description = "ECS task execution role name"
+  default     = "myEcsTaskExecutionRole"
+}
+
+variable "ecs_auto_scale_role_name" {
+  description = "ECS auto scale role name"
+  default     = "myEcsAutoScaleRole"
+}
+
+variable "az_count" {
+  description = "Number of availability zones to use"
+  default     = 2
+}
+
+variable "app_image" {
+  description = "The Docker image to use for the app"
+  default     = "bradfordhamilton/crystal_blockchain:latest"
+}
+
+variable "app_port" {
+  description = "The port the app listens on"
+  default     = 3000
+}
+
+variable "app_count" {
+  description = "The number of app instances to run"
+  default     = 3
+}
+
+variable "fargate_cpu" {
+  description = "The amount of CPU to allocate to each Fargate task"
+  default     = 1024
+}
+
+variable "fargate_memory" {
+  description = "The amount of memory to allocate to each Fargate task"
+  default     = 2048
+}


### PR DESCRIPTION
## Description

### Overview
This pull request introduces the necessary Terraform configuration to provision the ECS infrastructure on AWS. The infrastructure includes the definition of variables required for the AWS provider configuration.

### Changes Made
The following variables have been defined to parameterize the ECS infrastructure setup:
- `aws_access_key`: The IAM public access key.
- `aws_secret_key`: The IAM secret access key.
- `aws_region`: The AWS region to use.
- `ec2_task_execution_role_name`: ECS task execution role name (default: "myEcsTaskExecutionRole").
- `ecs_auto_scale_role_name`: ECS auto scale role name (default: "myEcsAutoScaleRole").
- `az_count`: Number of availability zones to use (default: 2).
- `app_image`: The Docker image to use for the app (default: "bradfordhamilton/crystal_blockchain:latest").
- `app_port`: The port the app listens on (default: 3000).
- `app_count`: The number of app instances to run (default: 3).
- `fargate_cpu`: The amount of CPU to allocate to each Fargate task (default: 1024).
- `fargate_memory`: The amount of memory to allocate to each Fargate task (default: 2048).

### Testing
The proposed changes have been locally tested to ensure the variables are properly defined and can be utilized in subsequent Terraform modules. Further testing will be performed in the target AWS environment during the deployment phase.

### Related Issues
[Link to any related issues, if applicable]

## Checklist
- [x] Code follows Terraform best practices.
- [x] Descriptive variable names and comments are used.
- [x] Local testing has been performed.
- [x] Documentation (if any) has been updated.
- [x] No hard-coded secrets or sensitive information in the code.
