### PR TITLE
Chore/create security configs

### DIFF
--- a/network.tf
+++ b/network.tf
@@ -1,0 +1,52 @@
+data "aws_availability_zones" "available" {
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "172.17.0.0/16"
+}
+
+resource "aws_subnet" "private" {
+  count             = var.az_count
+  cidr_block        = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index)
+  availability_zone = data.aws_availability_zones.available.names[count.index]
+  vpc_id            = aws_vpc.main.id
+}
+
+resource "aws_subnet" "public" {
+  count                   = var.az_count
+  cidr_block              = cidrsubnet(aws_vpc.main.cidr_block, 8, count.index + var.az_count)
+  availability_zone       = data.aws_availability_zones.available.names[count.index]
+  vpc_id                  = aws_vpc.main.id
+  map_public_ip_on_launch = true
+}
+
+resource "aws_internet_gateway" "gw" {
+  vpc_id = aws_vpc.main.id
+}
+
+resource "aws_route" "route_internet_gateway" {
+  route_table_id         = aws_vpc.main.main_route_table_id
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.gw.id
+}
+
+resource "aws_eip" "gw" {
+  count      = var.az_count
+  domain     = "vpc"
+  depends_on = [aws_internet_gateway.gw]
+}
+
+resource "aws_route_table" "private" {
+  count  = var.az_count
+  vpc_id = aws_vpc.main.id
+  route {
+    cidr_block     = "0.0.0.0/0"
+    nat_gateway_id = element(aws_nat_gateway.nat.*.id, count.index)
+  }
+}
+
+resource "aws_route_table_association" "private" {
+  count          = var.az_count
+  subnet_id      = element(aws_subnet.private.*.id, count.index)
+  route_table_id = element(aws_route_table.private.*.id, count.index)
+}

--- a/security.tf
+++ b/security.tf
@@ -1,0 +1,37 @@
+resource "aws_security_group" "lb" {
+  name        = "cb-load-balancer-security-group"
+  description = "Controls the load balancer security group"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol  = "tcp"
+    from_port = var.app_port
+    to_port   = var.app_port
+    cidr_blocks = [
+      "0.0.0.0/0"
+    ]
+  }
+}
+
+resource "aws_security_group" "ecs_tasks" {
+  name        = "cb-ecs-tasks-security-group"
+  description = "Allow inbound traffic from load balancer only"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    protocol  = "tcp"
+    from_port = var.app_port
+    to_port   = var.app_port
+    security_groups = [
+      aws_security_group.lb.id
+    ]
+  }
+
+  egress {
+    protocol  = "-1"
+    from_port = 0
+    to_port   = 0
+    cidr_blocks = [
+    "0.0.0.0/0"]
+  }
+}


### PR DESCRIPTION
## Terraform Infrastructure Changes

This pull request introduces changes to set up the networking infrastructure and security groups for an ECS-based application.

### Changes Made

#### Network Configuration (`network.tf`)
- Added VPC with CIDR block `172.17.0.0/16`.
- Created private and public subnets across available AWS availability zones (`var.az_count`).
- Configured an internet gateway for public subnet access.
- Established route tables for private subnets with NAT gateways for internet access.
- Assigned Elastic IPs for NAT gateways.

#### Security Groups Configuration (`security.tf`)
- Defined a security group for the load balancer (`aws_security_group.lb`).
  - Allows inbound traffic on specified application port (`var.app_port`) from any source (`0.0.0.0/0`).

- Defined a security group for ECS tasks (`aws_security_group.ecs_tasks`).
  - Allows inbound traffic only from the load balancer's security group.
  - Allows all outbound traffic (`0.0.0.0/0`).

### Context
The network configuration establishes the foundational components for the ECS infrastructure, including VPC, subnets, and internet connectivity. The security groups are designed to control traffic to and from the ECS tasks and the load balancer.

### Testing
Ensure that the network infrastructure is created successfully, and security groups are applied as intended. Verify that the security groups allow traffic based on the defined rules.

### Checklist
- [x] Network configuration is aligned with project requirements.
- [x] Security groups are appropriately configured for load balancer and ECS tasks.
- [x] No unnecessary changes in other files.

Please review and merge this PR to proceed with setting up the networking and security components for the ECS infrastructure.
