### PR TITLE
Chore/create server resources

### DIFF
--- a/alb.tf
+++ b/alb.tf
@@ -1,0 +1,34 @@
+resource "aws_alb" "main" {
+  name    = "cb-load-balancer"
+  subnets = aws_subnet.public.*.id
+  security_groups = [
+    aws_security_group.lb.id
+  ]
+}
+
+resource "aws_alb_target_group" "app" {
+  name        = "cb-target-group"
+  port        = 80 # 443 for production
+  protocol    = "HTTP"
+  vpc_id      = aws_vpc.main.id
+  target_type = "ip"
+  health_check {
+    healthy_threshold   = "3"
+    interval            = "30"
+    protocol            = "HTTP"
+    matcher             = "200"
+    timeout             = "3"
+    path                = var.health_check_path
+    unhealthy_threshold = "2"
+  }
+}
+
+resource "aws_alb_listener" "front_end" {
+  load_balancer_arn = aws_alb.main.id
+  port              = var.app_port
+  protocol          = "HTTP"
+  default_action {
+    target_group_arn = aws_alb_target_group.app.id
+    type             = "forward"
+  }
+}

--- a/auto_scaling.tf
+++ b/auto_scaling.tf
@@ -1,0 +1,87 @@
+resource "aws_appautoscaling_target" "target" {
+  service_namespace  = "ecs"
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.main.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+  role_arn           = aws_iam_role.ecs_task_execution_role.arn
+  min_capacity       = 3
+  max_capacity       = 6
+}
+
+resource "aws_appautoscaling_policy" "up" {
+  name               = "cb_scale_up"
+  service_namespace  = "ecs"
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.main.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
+    metric_aggregation_type = "Maximum"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = 1
+    }
+  }
+
+  depends_on = [aws_appautoscaling_target.target]
+}
+
+resource "aws_appautoscaling_policy" "down" {
+  name               = "cb_scale_down"
+  service_namespace  = "ecs"
+  resource_id        = "service/${aws_ecs_cluster.main.name}/${aws_ecs_service.main.name}"
+  scalable_dimension = "ecs:service:DesiredCount"
+
+  step_scaling_policy_configuration {
+    adjustment_type         = "ChangeInCapacity"
+    cooldown                = 60
+    metric_aggregation_type = "Maximum"
+
+    step_adjustment {
+      metric_interval_lower_bound = 0
+      scaling_adjustment          = -1
+    }
+  }
+
+  depends_on = [aws_appautoscaling_target.target]
+}
+
+resource "aws_cloudwatch_metric" "service_cpu_high" {
+  alarm_name          = "cb_cpu_utilization_high"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "85"
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.main.name
+    ServiceName = aws_ecs_service.main.name
+  }
+
+  alarm_actions = [aws_appautoscaling_policy.up.arn]
+}
+
+resource "aws_cloudwatch_metric" "service_cpu_low" {
+  alarm_name          = "cb_cpu_utilization_low"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "2"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ECS"
+  period              = "60"
+  statistic           = "Average"
+  threshold           = "10"
+
+  dimensions = {
+    ClusterName = aws_ecs_cluster.main.name
+    ServiceName = aws_ecs_service.main.name
+  }
+
+  alarm_actions = [aws_appautoscaling_policy.down.arn]
+}
+
+
+

--- a/ecs.tf
+++ b/ecs.tf
@@ -1,0 +1,50 @@
+resource "aws_ecs_cluster" "main" {
+  name = "cb-cluster"
+}
+
+data "template_file" "cb_app" {
+  template = file("./templates/ecs/cb_app.json.tpl")
+
+  vars = {
+    app_image      = var.app_image
+    app_port       = var.app_port
+    fargate_cpu    = var.fargate_cpu
+    fargate_memory = var.fargate_memory
+    aws_region     = var.aws_region
+  }
+}
+
+resource "aws_ecs_task_definition" "app" {
+  family             = "cb-app-task"
+  execution_role_arn = aws_iam_role.ecs_task_execution_role.arn
+  network_mode       = "awsvpc"
+  requires_compatibilities = [
+    "FARGATE"
+  ]
+  cpu                   = var.fargate_cpu
+  memory                = var.fargate_memory
+  container_definitions = data.template_file.cb_app.rendered
+}
+
+resource "aws_ecs_service" "main" {
+  name            = "cb-service"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count   = var.app_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    subnets          = aws_subnet.private.*.id
+    assign_public_ip = true
+  }
+
+  load_balancer {
+    target_group_arn = aws_alb_target_group.app.id
+    container_name   = "cb-app"
+    container_port   = var.app_port
+  }
+
+  depends_on = [aws_alb_listener.front_end, aws_iam_role_policy_attachment.ecs-task-execution-role-policy-attachment]
+
+}

--- a/templates/ecs/cb_app.json.tpl
+++ b/templates/ecs/cb_app.json.tpl
@@ -1,0 +1,23 @@
+[
+  {
+    "name": "cb-app",
+    "image": "${app_image}",
+    "cpu": ${fargate_cpu},
+    "memory": ${fargate_memory},
+    "networkMode": "awsvpc",
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+          "awslogs-group": "/ecs/cb-app",
+          "awslogs-region": "${aws_region}",
+          "awslogs-stream-prefix": "ecs"
+        }
+    },
+    "portMappings": [
+      {
+        "containerPort": ${app_port},
+        "hostPort": ${app_port}
+      }
+    ]
+  }
+]

--- a/variables.tf
+++ b/variables.tf
@@ -40,6 +40,11 @@ variable "app_count" {
   default     = 3
 }
 
+variable "health_check_path" {
+  description = "The path to use for the health check"
+  default     = "/"
+}
+
 variable "fargate_cpu" {
   description = "The amount of CPU to allocate to each Fargate task"
   default     = 1024


### PR DESCRIPTION
## Terraform ECS Infrastructure Changes

This pull request introduces the configuration for ECS infrastructure, including the Application Load Balancer (ALB), ECS Cluster, Task Definition, and Auto Scaling policies.

### Changes Made

#### ALB Configuration (`alb.tf`)
- Defined an Application Load Balancer (`aws_alb.main`) with a specified name and associated security groups.
- Created an ALB target group (`aws_alb_target_group.app`) for routing traffic to ECS tasks.
- Configured an ALB listener (`aws_alb_listener.front_end`) to forward traffic to the defined target group.

#### ECS Configuration (`ecs.tf`)
- Established an ECS Cluster (`aws_ecs_cluster.main`) with the name "cb-cluster."
- Defined a template file (`data.template_file.cb_app`) for ECS Task Definition using a JSON template.
- Created an ECS Task Definition (`aws_ecs_task_definition.app`) with Fargate compatibility, CPU and memory specifications, and container definitions from the template.
- Configured an ECS Service (`aws_ecs_service.main`) with desired task count, launch type as Fargate, network configuration, and load balancer settings.

#### Auto Scaling Configuration (`auto_scaling.tf`)
- Set up Auto Scaling for the ECS Service using AWS AppAutoscaling.
- Defined an Auto Scaling target (`aws_appautoscaling_target.target`) for the ECS Service.
- Created Auto Scaling policies (`aws_appautoscaling_policy.up` and `aws_appautoscaling_policy.down`) for scaling up and down based on CPU utilization.
- Configured CloudWatch Alarms (`aws_cloudwatch_metric.service_cpu_high` and `aws_cloudwatch_metric.service_cpu_low`) to trigger the Auto Scaling policies based on CPU utilization metrics.

### Context
These changes enable the deployment of ECS tasks within a cluster, fronted by an Application Load Balancer. Auto Scaling policies are implemented to dynamically adjust the number of tasks based on CPU utilization.

### Testing
Ensure the ECS infrastructure provisions successfully, and the Auto Scaling policies respond appropriately to changes in CPU utilization. Verify that the ALB routes traffic to ECS tasks as expected.

### Checklist
- [x] ALB, ECS Cluster, and Task Definition configurations align with project requirements.
- [x] Auto Scaling policies and CloudWatch Alarms are appropriately configured.
- [ ] No unnecessary changes in other files.

Please review and merge this PR to implement ECS infrastructure with ALB and Auto Scaling capabilities.
