### PR TITLE
hotfix/fix-wrong-resource-names

### DIFF
--- a/auto_scaling.tf
+++ b/auto_scaling.tf
@@ -47,7 +47,7 @@ resource "aws_appautoscaling_policy" "down" {
   depends_on = [aws_appautoscaling_target.target]
 }
 
-resource "aws_cloudwatch_metric" "service_cpu_high" {
+resource "aws_cloudwatch_metric_alarm" "service_cpu_high" {
   alarm_name          = "cb_cpu_utilization_high"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "2"
@@ -65,7 +65,7 @@ resource "aws_cloudwatch_metric" "service_cpu_high" {
   alarm_actions = [aws_appautoscaling_policy.up.arn]
 }
 
-resource "aws_cloudwatch_metric" "service_cpu_low" {
+resource "aws_cloudwatch_metric_alarm" "service_cpu_low" {
   alarm_name          = "cb_cpu_utilization_low"
   comparison_operator = "LessThanOrEqualToThreshold"
   evaluation_periods  = "2"

--- a/network.tf
+++ b/network.tf
@@ -47,7 +47,7 @@ resource "aws_route_table" "private" {
   vpc_id = aws_vpc.main.id
   route {
     cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = element(aws_nat_gateway.nat.*.id, count.index)
+    nat_gateway_id = element(aws_nat_gateway.gw.*.id, count.index)
   }
 }
 


### PR DESCRIPTION
## Description

### Overview
This pull request addresses specific issues within the ECS infrastructure Terraform code. The changes include corrections to the auto-scaling configuration in `auto_scaling.tf` and a fix in the network setup in `network.tf`.

### Changes Made

#### `auto_scaling.tf`
- **Correction:** Resolved an issue in the definition of the `aws_cloudwatch_metric_alarm` resource for high CPU utilization. The resource type has been updated to `aws_cloudwatch_metric_alarm`.

#### `network.tf`
- **Correction:** Fixed an issue in the definition of the `aws_route_table` resource for the private subnet. The `nat_gateway_id` attribute has been updated to correctly reference the NAT gateway IDs.

### Testing
The proposed changes have been locally tested to ensure that the corrected configurations work as expected. Further testing will be performed in the target AWS environment during the deployment phase.

### Related Issues
[Link to any related issues, if applicable]

## Checklist
- [x] Code follows Terraform best practices.
- [x] Descriptive variable names and comments are used.
- [x] Local testing has been performed.
- [x] Documentation (if any) has been updated.
- [x] No hard-coded secrets or sensitive information in the code.
